### PR TITLE
add missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,12 @@
   },
   "dependencies": {
     "midi.freq": "^1.0.0",
+    "note-parser": "^0.9.0",
     "note.midi": "0.0.3"
   },
   "devDependencies": {
+    "browserify": "^12.0.2",
+    "uglifyjs": "^2.4.10",
     "vows": "0.8.x"
   }
 }


### PR DESCRIPTION
Hi, I wanted to run the examples locally and ```npm install``` failed because ```note-parser``` wasn't in package JSON. It also failed because I don't have ```browserify``` and ```uglifyjs``` installed globally, so I added those as devDependencies so it's not necessary to already have them globally installed.