### PR TITLE
Adds mocha, browserify, and uglify as dev deps in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "note-midi": "^1.0.1"
   },
   "devDependencies": {
+    "browserify": "^13.0.0",
+    "mocha": "*",
+    "uglifyjs": "^2.4.10"
   }
 }


### PR DESCRIPTION
Mocha, browserify, and uglify seem to all be used for development. This change just adds these packages to the `package.json` as dev dependencies instead of assuming they are globally installed.