### PR TITLE
Update buffers-player.js

### DIFF
--- a/lib/buffers-player.js
+++ b/lib/buffers-player.js
@@ -30,9 +30,11 @@ module.exports = function (ctx, buffers, defaultOptions) {
     vca.gain.value = gain
     source.connect(vca)
     vca.connect(destination)
-
-    source.start(time)
-    if (duration > 0) source.stop(time + duration)
+    if (duration > 0) {
+      source.start(time, 0, duration)
+    } else {
+      source.start(time)
+    }
     return source
   }
 }


### PR DESCRIPTION
Why use the stop (what had some weird side effects in my application) if you can just set the duration as start parameter?

https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start