### PR TITLE
add notes options to the instrument load

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ Soundfont.prototype.instrument = function (name, options) {
   if (name in this.instruments) return this.instruments[name]
   var inst = { name: name, play: oscillatorPlayer(ctx, options) }
   this.instruments[name] = inst
-  var promise = loadBank(ctx, this.nameToUrl(name)).then(function (buffers) {
+  var promise = loadBank(ctx, this.nameToUrl(name), options.notes).then(function (buffers) {
     inst.play = buffersPlayer(ctx, buffers, options)
     return inst
   })

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ var buffersPlayer = require('./buffers-player')
  * @param {Function} nameToUrl - (Optional) a function that maps the sound font name to the url
  * @return {Soundfont} a soundfont object
  */
-function Soundfont (ctx, nameToUrl) {
+function Soundfont(ctx, nameToUrl) {
   if (!(this instanceof Soundfont)) return new Soundfont(ctx)
 
   this.nameToUrl = nameToUrl || Soundfont.nameToUrl || gleitzUrl
@@ -28,14 +28,17 @@ Soundfont.prototype.instrument = function (name, options) {
   var ctx = this.ctx
   name = name || 'default'
   if (name in this.instruments) return this.instruments[name]
-  var inst = { name: name, play: oscillatorPlayer(ctx, options) }
+  var inst = {name: name, play: oscillatorPlayer(ctx, options)}
+  var notes = options ? options.notes : undefined;
   this.instruments[name] = inst
-  var promise = loadBank(ctx, this.nameToUrl(name), options.notes).then(function (buffers) {
+  var promise = loadBank(ctx, this.nameToUrl(name), notes).then(function (buffers) {
     inst.play = buffersPlayer(ctx, buffers, options)
     return inst
   })
   this.promises.push(promise)
-  inst.onready = function (cb) { promise.then(cb) }
+  inst.onready = function (cb) {
+    promise.then(cb)
+  }
   return inst
 }
 
@@ -51,7 +54,7 @@ Soundfont.loadBuffers = function (ctx, name) {
  * @param {String} name - instrument name
  * @returns {String} the Soundfont file url
  */
-function gleitzUrl (name) {
+function gleitzUrl(name) {
   return 'https://cdn.rawgit.com/gleitz/midi-js-Soundfonts/master/FluidR3_GM/' + name + '-ogg.js'
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ Soundfont.prototype.instrument = function (name, options) {
   var inst = {name: name, play: oscillatorPlayer(ctx, options)}
   var notes = options ? options.notes : undefined;
   this.instruments[name] = inst
-  var promise = loadBank(ctx, this.nameToUrl(name), notes).then(function (buffers) {
+  var promise = loadBank(ctx, this.nameToUrl(name), undefined, undefined, notes).then(function (buffers) {
     inst.play = buffersPlayer(ctx, buffers, options)
     return inst
   })

--- a/lib/load-bank.js
+++ b/lib/load-bank.js
@@ -11,18 +11,22 @@ var decodeBuffer = require('./decode-buffer')
  * @param {Function} get - (Optional) given a url return a promise with the contents
  * @param {Function} parse - (Optinal) given a js file return JSON object
  */
-module.exports = function (ctx, url, get, parse) {
-  get = get || getContent
-  parse = parse || parseJavascript
+module.exports = function (ctx, url, notes) {
+  var get = getContent
+  var parse = parseJavascript
   return Promise.resolve(url).then(get).then(parse)
     .then(function (data) {
-      return { ctx: ctx, data: data, buffers: {} }
+      return {ctx: ctx, data: data, buffers: {}}
     })
-    .then(decodeBank)
-    .then(function (bank) { return bank.buffers })
+    .then(function (data) {
+      return decodeBank(data, notes)
+    })
+    .then(function (bank) {
+      return bank.buffers
+    })
 }
 
-function getContent (url) {
+function getContent(url) {
   return new Promise(function (done, reject) {
     var req = new window.XMLHttpRequest()
     req.open('GET', url)
@@ -49,7 +53,7 @@ function getContent (url) {
  * @return {JSON} the parsed data as JSON object
  * @api private
  */
-function parseJavascript (data) {
+function parseJavascript(data) {
   var begin = data.indexOf('MIDI.Soundfont.')
   begin = data.indexOf('=', begin) + 2
   var end = data.lastIndexOf(',')
@@ -62,13 +66,24 @@ function parseJavascript (data) {
  * @return {Promise} a promise that resolves to the bank with the buffers decoded
  * @api private
  */
-function decodeBank (bank) {
+function decodeBank(bank, notes) {
   var promises = Object.keys(bank.data).map(function (note) {
-    return decodeBuffer(bank.ctx, bank.data[note])
-    .then(function (buffer) {
-      bank.buffers[midi(note)] = buffer
-    })
-  })
+    // First check is notes are passed by as param
+    if (typeof notes !== 'undefined') {
+      // if the current notes is needed for the instrument.
+      if (notes.indexOf(note) !== -1) {
+        return decodeBuffer(bank.ctx, bank.data[note])
+          .then(function (buffer) {
+            bank.buffers[midi(note)] = buffer
+          })
+      }
+    } else {
+      return decodeBuffer(bank.ctx, bank.data[note])
+        .then(function (buffer) {
+          bank.buffers[midi(note)] = buffer
+        })
+    }
+  });
 
   return Promise.all(promises).then(function () {
     return bank

--- a/lib/load-bank.js
+++ b/lib/load-bank.js
@@ -63,6 +63,7 @@ function parseJavascript(data) {
 /*
  * Decode a bank
  * @param {Object} bank - the bank object
+ * @param {Array} notes - an array of required notes
  * @return {Promise} a promise that resolves to the bank with the buffers decoded
  * @api private
  */
@@ -71,8 +72,12 @@ function decodeBank(bank, notes) {
   var promises = Object.keys(bank.data).map(function (note) {
     // First check is notes are passed by as param
     if (typeof notes !== 'undefined') {
+      // convert the notes to midi number
+      var notesMidi = notes.map(function(note){
+        return midi(note);
+      })
       // if the current notes is needed for the instrument.
-      if (notes.indexOf(note) !== -1) {
+      if (notesMidi.indexOf(midi(note)) !== -1) {
         return decodeBuffer(bank.ctx, bank.data[note])
           .then(function (buffer) {
             bank.buffers[midi(note)] = buffer
@@ -90,3 +95,4 @@ function decodeBank(bank, notes) {
     return bank
   })
 }
+

--- a/lib/load-bank.js
+++ b/lib/load-bank.js
@@ -11,9 +11,9 @@ var decodeBuffer = require('./decode-buffer')
  * @param {Function} get - (Optional) given a url return a promise with the contents
  * @param {Function} parse - (Optinal) given a js file return JSON object
  */
-module.exports = function (ctx, url, notes) {
-  var get = getContent
-  var parse = parseJavascript
+module.exports = function (ctx, url, get, parse, notes) {
+  get = get || getContent
+  parse = parse || parseJavascript
   return Promise.resolve(url).then(get).then(parse)
     .then(function (data) {
       return {ctx: ctx, data: data, buffers: {}}

--- a/lib/load-bank.js
+++ b/lib/load-bank.js
@@ -66,6 +66,7 @@ function parseJavascript(data) {
  * @return {Promise} a promise that resolves to the bank with the buffers decoded
  * @api private
  */
+
 function decodeBank(bank, notes) {
   var promises = Object.keys(bank.data).map(function (note) {
     // First check is notes are passed by as param


### PR DESCRIPTION
Hi, 

This is just a raw suggestion, when loading a instrument you load all the notes for the instruments, but sometimes you don't need all of them when playing a midi file. So i propose you can pass in an extra option for an instrument -> notes. Using this note list, the buffer will only load the given notes and not everything in the file.

This is mainly a performance update, because you are base64 decoding and mp3 decoding all the notes. What can be very cpu hungry when loading instruments. In my application i could bring down load time significantly:

I added a timer start before instrument loades and a timer stop on soundfont.onready

For example a midifile with 16 different instruments(all in browser cache):
before: 11758 ms
after: 2253 ms
For example a midifile with 1 instrument(in browser cache):
before: 739 ms
after: 148 ms


Again this is a very raw pull request, any suggestions or style remarks are welcome.