### PR TITLE
Optimise sound cutoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 CHANGELOG
-
+[0.8.3]
+- Use Ramp up to value functions for enabling and disabling the gain, when note duration is set.
 [0.8.2]
 - Standard JS style support
 - Add `notes` options

--- a/lib/bank-player.js
+++ b/lib/bank-player.js
@@ -27,11 +27,12 @@ module.exports = function (ctx, bank, defaultOptions) {
 
     /* VCA */
     var vca = ctx.createGain()
-    vca.gain.value = gain
     source.connect(vca)
     vca.connect(destination)
+    vca.gain.linearRampToValueAtTime(gain, ctx.currentTime)
     if (duration > 0) {
       source.start(time, 0, duration)
+      vca.gain.exponentialRampToValueAtTime(0.1, ctx.currentTime + duration)
     } else {
       source.start(time)
     }


### PR DESCRIPTION
When having a duration that is shorter then the note it can create small cut off sounds at the end of the sound. This small edit irons them out by adding an ramp on intro but also on outro.