### PR TITLE
Use https for soundfonts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -72,7 +72,7 @@ function isSoundfontURL (name) {
 function nameToUrl (name, sf, format) {
   format = format === 'ogg' ? format : 'mp3'
   sf = sf === 'FluidR3_GM' ? sf : 'MusyngKite'
-  return 'http://gleitz.github.io/midi-js-soundfonts/' + sf + '/' + name + '-' + format + '.js'
+  return 'https://gleitz.github.io/midi-js-soundfonts/' + sf + '/' + name + '-' + format + '.js'
 }
 
 // In the 1.0.0 release it will be:


### PR DESCRIPTION
This allows it to work from an HTTPS site without causing mixed content errors.