### PR TITLE
Fix/typescript bindings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -130,7 +130,7 @@ declare type InstrumentName =
 
 export declare type Player = {
   start: (
-    name: string,
+    name: number,
     when?: number,
     options?: Partial<{
       gain: number;
@@ -151,7 +151,7 @@ export declare type Player = {
   listenToMidi: (midiInput: any, options?: any) => Player;
 };
 export declare const instrument: (
-  ac: typeof AudioContext,
+  ac: AudioContext,
   name: InstrumentName,
   options?: any
 ) => Promise<Player>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,7 +130,7 @@ declare type InstrumentName =
 
 export declare type Player = {
   start: (
-    name: number,
+    name: number | string,
     when?: number,
     options?: Partial<{
       gain: number;
@@ -151,7 +151,7 @@ export declare type Player = {
   listenToMidi: (midiInput: any, options?: any) => Player;
 };
 export declare const instrument: (
-  ac: AudioContext,
+  ac: AudioContext | typeof AudioContext,
   name: InstrumentName,
   options?: any
 ) => Promise<Player>;


### PR DESCRIPTION
`Player` definitely accepts `number` or `string`.

In my use, `instrument` was buggy to use at least in Safari without having it also accept `AudioContext` in addition to `typeof AudioContext` even though the two should be equivalent.