### PR TITLE
Use AudioContext as type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -151,7 +151,7 @@ export declare type Player = {
   listenToMidi: (midiInput: any, options?: any) => Player;
 };
 export declare const instrument: (
-  ac: typeof AudioContext,
+  ac: AudioContext,
   name: InstrumentName,
   options?: any
 ) => Promise<Player>;


### PR DESCRIPTION
When I try to use this library from TypeScript, I get a type error when passing an `AudioContext` into the `instrument` function:

```
Argument of type 'AudioContext' is not assignable to parameter of type '{ new (contextOptions?: AudioContextOptions): AudioContext; prototype: AudioContext; }'.
  Property 'prototype' is missing in type 'AudioContext' but required in type '{ new (contextOptions?: AudioContextOptions): AudioContext; prototype: AudioContext; }'
```

It seems that the type of `ac` should just be `AudioContext`, rather than `typeof AudioContext`. When I make this change in your `index.d.ts`, the type error goes away.